### PR TITLE
Missing typename

### DIFF
--- a/CSVReader.h
+++ b/CSVReader.h
@@ -821,7 +821,7 @@ namespace CSVReader {
         typedef typename csv_reader_type::value_type value_type;
 
         static_assert(std::is_same<CharT, value_type>::value, "Value type of basic_string must be the same as the type of the seperator!");
-        return csv_reader_type::full_type(reader, sep);
+        return typename csv_reader_type::full_type(reader, sep);
     }
 
 


### PR DESCRIPTION
Solving the following compilation error in GCC:
CSVReader.h:824:42: error: dependent-name ‘csv_reader_type:: full_type’ is parsed as a non-type, but instantiation yields a type
         return csv_reader_type::full_type(reader, sep);

Compiler indicated this:
note: say ‘typename csv_reader_type:: full_type’ if a type is meant